### PR TITLE
Fixed issue with MANIFEST.in and setup.py causing issue with headers …

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-recursive-include cpp_src 
+recursive-include cpp_src *.cpp *.h
 include pkechomidi.py setup_pkechomidi.py

--- a/setup.py
+++ b/setup.py
@@ -61,10 +61,18 @@ CPP_FNAMES = ['RtMidi.cpp',
               'rtmidimodule.cpp',
               ]
 
+CPP_HEADERS = ['RtMidi.h',
+               'pkglobals.h',
+               'MidiMessage.h',
+               'PyMidiMessage.h'
+               ]
+
 cpp_sources = [os.path.join(CPP_SRC_DIR, fname) for fname in CPP_FNAMES]
+cpp_headers = [os.path.join(CPP_SRC_DIR, fname) for fname in CPP_HEADERS]
 
 midi = Extension(name='rtmidi._rtmidi',
                  sources=cpp_sources,
+                 headers=cpp_headers,
                  library_dirs=library_dirs,
                  libraries=libraries,
                  define_macros=define_macros,


### PR DESCRIPTION
…not being put on pypi

Hi again,

We are closer to the fix! This one seemed to do it. For some reason, even the "recursive include" omitted the header files without it explicitly being selected as a pattern. 

Lets try this again. I'm happy to pull it back down off of pypi until I get it right! 

Cheers