### PR TITLE
Linux: fix compilation macro

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ library_dirs = []
 
 
 if OSNAME == 'Linux':
-    define_macros = [("__LINUX_ALSASEQ__", '')]
+    define_macros = [("__LINUX_ALSA__", '')]
     libraries = ['asound', 'pthread']
 elif OSNAME == 'Darwin':
     define_macros = [('__MACOSX_CORE__', '')]


### PR DESCRIPTION
According to http://www.music.mcgill.ca/%7Egary/rtmidi/index.html#compiling, the compilation macro for linux is `__LINUX_ALSA__`, not `__LINUX_ALSASEQ__`. Without it, rtmidi returns dummy objects on linux.
Thanks for the lib ;)