### PR TITLE
Add --jack-midi compilation option

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ library_dirs = []
 
 
 if OSNAME == 'Linux':
-    define_macros = [("__LINUX_ALSA__", '')]
+    define_macros = [('__LINUX_ALSA__', '')]
     libraries = ['asound', 'pthread']
 elif OSNAME == 'Darwin':
     define_macros = [('__MACOSX_CORE__', '')]
@@ -54,6 +54,11 @@ elif OSNAME == 'Windows':
 elif OSNAME == 'Irix':
     define_macros = [('__IRIX_MD__', '')]
     libraries = ['pthread', 'md']
+
+if '--jack-midi' in argv:
+    define_macros.append(('__UNIX_JACK__', ''))
+    libraries.append('jack')
+    argv.pop(argv.index('--jack-midi'))
 
 CPP_SRC_DIR = 'cpp_src'
 CPP_FNAMES = ['RtMidi.cpp',


### PR DESCRIPTION
This add support for a `--jack-midi` compilation option that adds make the jack midi api work. One can specify the midi api this way:

```python
import rtmidi

dev = rtmidi.RtMidiIn(0, 'ClientName') # 0 = unspecified api, use first available
jackmidi_dev = rtmidi.RtMidiIn(3, 'ClientName') # 3 = use jack midi api
```

The last statement requires the lib to be compiled with --jack-midi to work.