### PR TITLE
Unify RtMidiOut and RtMidiIn api / syntax (remerge pull request #8)

### DIFF
--- a/cpp_src/rtmidimodule.cpp
+++ b/cpp_src/rtmidimodule.cpp
@@ -600,15 +600,18 @@ MidiOut_dealloc(MidiOut *self)
 static PyObject *
 MidiOut_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
-  char *name = NULL;
+  RtMidiOut::Api api = RtMidiOut::UNSPECIFIED;
+  char *clientName = (char *) ""; // avoid clang warnings;
+  MidiOut *self = NULL;
 
-  if(!PyArg_ParseTuple(args, "|s", &name))
+  if(!PyArg_ParseTuple(args, "|is", &api, &clientName))
     return NULL;
 
-  MidiOut *self = (MidiOut *) type->tp_alloc(type, 0);
+  self = (MidiOut *) type->tp_alloc(type, 0);
+
   try
     {
-      self->rtmidi = new RtMidiOut;
+      self->rtmidi = new RtMidiOut(api, clientName);
     }
   catch(RtMidiError &error)
     {

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ setup(name='rtmidi',
       author_email='patrickkidd@gmail.com',
       url='https://github.com/patrickkidd/pyrtmidi',
       keywords=['midi audio hardware'],
-      version='2.3.1',
+      version='2.3.2',
       description = """Python RtMidi interface
 def print_message(midi):
     if midi.isNoteOn():


### PR DESCRIPTION
https://github.com/patrickkidd/pyrtmidi/pull/8 was reverted in ad47f914e3352e5b9b20934a7b6a6af93dd016bb, this re-merges it and increment the version number.