### PR TITLE
prevent buffer overflow crash on certain getMidiNoteName numbers (issue #12)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,4 @@
-Version 2.3.3
+Version 2.3.4
 =========================================
 - Fixed bug where noteOn would always set channel to zero on linux.
 

--- a/cpp_src/MidiMessage.cpp
+++ b/cpp_src/MidiMessage.cpp
@@ -1049,7 +1049,7 @@ const char *MidiMessage::getMidiNoteName (int note,
 
     if (((unsigned int) note) < 128)
     {
-      static char buf[4];
+      static char buf[16];
       const char *noteName = (useSharps) ? sharpNoteNames [note % 12] : flatNoteNames [note % 12];
       if (includeOctaveNumber)
         sprintf(buf, "%s%i", noteName, note / 12 + (octaveNumForMiddleC - 5));

--- a/setup.py
+++ b/setup.py
@@ -90,9 +90,9 @@ setup(name='rtmidi',
       author='Patrick Stinson',
       author_email='patrickkidd@gmail.com',
       url='https://github.com/patrickkidd/pyrtmidi',
-      download_url='https://github.com/patrickkidd/pyrtmidi/tarball/2.3.3',
+      download_url='https://github.com/patrickkidd/pyrtmidi/tarball/2.3.4',
       keywords=['midi audio hardware'],
-      version='2.3.3',
+      version='2.3.4',
       description = """Python RtMidi interface
 def print_message(midi):
     if midi.isNoteOn():


### PR DESCRIPTION
See #12, this also bumps the version to 2.3.4.